### PR TITLE
Add historical source

### DIFF
--- a/FaraData/migrations/0012_auto__add_historical.py
+++ b/FaraData/migrations/0012_auto__add_historical.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Historical'
+        db.create_table(u'FaraData_historical', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('principal', self.gf('django.db.models.fields.CharField')(max_length=255, null=True)),
+            ('principal_reg_date', self.gf('django.db.models.fields.DateField')(null=True, blank=True)),
+            ('principal_termination_date', self.gf('django.db.models.fields.DateField')(null=True, blank=True)),
+            ('address', self.gf('django.db.models.fields.CharField')(max_length=255, null=True)),
+            ('state', self.gf('django.db.models.fields.CharField')(max_length=255, null=True)),
+            ('location_represented', self.gf('django.db.models.fields.CharField')(max_length=255, null=True)),
+            ('registrant', self.gf('django.db.models.fields.CharField')(max_length=255, null=True)),
+            ('registrant_no', self.gf('django.db.models.fields.IntegerField')()),
+            ('registrant_reg_date', self.gf('django.db.models.fields.DateField')(null=True, blank=True)),
+            ('registrant_termination_date', self.gf('django.db.models.fields.DateField')(null=True, blank=True)),
+            ('document_type', self.gf('django.db.models.fields.CharField')(max_length=255, null=True)),
+            ('document_link', self.gf('django.db.models.fields.CharField')(max_length=255, null=True)),
+        ))
+        db.send_create_signal(u'FaraData', ['Historical'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'Historical'
+        db.delete_table(u'FaraData_historical')
+
+
+    models = {
+        u'FaraData.client': {
+            'Meta': {'object_name': 'Client'},
+            'address1': ('django.db.models.fields.CharField', [], {'max_length': '300', 'null': 'True', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'client_name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'client_type': ('django.db.models.fields.CharField', [], {'max_length': '25', 'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Location']"}),
+            'meta_data': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['FaraData.MetaData']", 'null': 'True', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'})
+        },
+        u'FaraData.clientreg': {
+            'Meta': {'object_name': 'ClientReg'},
+            'client_id': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Client']"}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'link': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'meta_data': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['FaraData.MetaData']", 'null': 'True', 'blank': 'True'}),
+            'primary_contractor_id': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'primary_contractor'", 'null': 'True', 'symmetrical': 'False', 'to': u"orm['FaraData.Registrant']"}),
+            'reg_id': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Registrant']"})
+        },
+        u'FaraData.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'client': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Client']", 'null': 'True'}),
+            'contact_type': ('django.db.models.fields.CharField', [], {'default': "'U'", 'max_length': '1'}),
+            'date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'link': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'lobbyist': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['FaraData.Lobbyist']", 'null': 'True', 'blank': 'True'}),
+            'meta_data': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.MetaData']", 'null': 'True', 'blank': 'True'}),
+            'recipient': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['FaraData.Recipient']", 'symmetrical': 'False'}),
+            'registrant': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Registrant']"})
+        },
+        u'FaraData.contribution': {
+            'Meta': {'object_name': 'Contribution'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'max_digits': '8', 'decimal_places': '2'}),
+            'date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'link': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'lobbyist': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Lobbyist']", 'null': 'True', 'blank': 'True'}),
+            'meta_data': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.MetaData']", 'null': 'True', 'blank': 'True'}),
+            'recipient': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Recipient']"}),
+            'registrant': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Registrant']"})
+        },
+        u'FaraData.disbursement': {
+            'Meta': {'object_name': 'Disbursement'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'max_digits': '12', 'decimal_places': '2'}),
+            'client': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Client']"}),
+            'date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'link': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'meta_data': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.MetaData']", 'null': 'True', 'blank': 'True'}),
+            'purpose': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'registrant': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Registrant']"}),
+            'subcontractor': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'subcontractor'", 'null': 'True', 'to': u"orm['FaraData.Registrant']"})
+        },
+        u'FaraData.gift': {
+            'Meta': {'object_name': 'Gift'},
+            'client': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['FaraData.Client']", 'null': 'True', 'blank': 'True'}),
+            'date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'link': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'meta_data': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.MetaData']", 'null': 'True', 'blank': 'True'}),
+            'purpose': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'recipient': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Recipient']", 'null': 'True', 'blank': 'True'}),
+            'registrant': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Registrant']"})
+        },
+        u'FaraData.historical': {
+            'Meta': {'object_name': 'Historical'},
+            'address': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'document_link': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'document_type': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location_represented': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'principal': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'principal_reg_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'principal_termination_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'registrant': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'registrant_no': ('django.db.models.fields.IntegerField', [], {}),
+            'registrant_reg_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'registrant_termination_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'})
+        },
+        u'FaraData.lobbyist': {
+            'Meta': {'object_name': 'Lobbyist'},
+            'PAC_name': ('django.db.models.fields.CharField', [], {'max_length': '150', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'lobby_id': ('django.db.models.fields.CharField', [], {'max_length': '150', 'null': 'True', 'blank': 'True'}),
+            'lobbyist_name': ('django.db.models.fields.CharField', [], {'max_length': '150', 'null': 'True', 'blank': 'True'})
+        },
+        u'FaraData.location': {
+            'Meta': {'object_name': 'Location'},
+            'country_code': ('django.db.models.fields.CharField', [], {'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'country_grouping': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '200'}),
+            'region': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        u'FaraData.metadata': {
+            'Meta': {'object_name': 'MetaData'},
+            'end_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'form': ('django.db.models.fields.CharField', [], {'max_length': '300'}),
+            'is_amendment': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'link': ('django.db.models.fields.CharField', [], {'max_length': '255', 'primary_key': 'True', 'db_index': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'processed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'reviewed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'upload_date': ('django.db.models.fields.DateField', [], {'null': 'True'})
+        },
+        u'FaraData.payment': {
+            'Meta': {'object_name': 'Payment'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'max_digits': '12', 'decimal_places': '2'}),
+            'client': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Client']"}),
+            'date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'fee': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'link': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'meta_data': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.MetaData']", 'null': 'True', 'blank': 'True'}),
+            'purpose': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'registrant': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Registrant']"}),
+            'sort_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'subcontractor': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'payment_subcontractor'", 'null': 'True', 'to': u"orm['FaraData.Registrant']"})
+        },
+        u'FaraData.recipient': {
+            'Meta': {'object_name': 'Recipient'},
+            'agency': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'bioguide_id': ('django.db.models.fields.CharField', [], {'max_length': '7', 'null': 'True', 'blank': 'True'}),
+            'crp_id': ('django.db.models.fields.CharField', [], {'max_length': '9', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '150', 'null': 'True'}),
+            'office_detail': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'state_local': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '300', 'null': 'True', 'blank': 'True'})
+        },
+        u'FaraData.registrant': {
+            'Meta': {'object_name': 'Registrant'},
+            'address': ('django.db.models.fields.CharField', [], {'max_length': '300', 'null': 'True', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'clients': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['FaraData.Client']", 'null': 'True', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'lobbyists': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['FaraData.Lobbyist']", 'null': 'True', 'blank': 'True'}),
+            'meta_data': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['FaraData.MetaData']", 'null': 'True', 'blank': 'True'}),
+            'reg_id': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'}),
+            'reg_name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '2', 'null': 'True', 'blank': 'True'}),
+            'terminated_clients': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'terminated_clients'", 'null': 'True', 'symmetrical': 'False', 'to': u"orm['FaraData.Client']"}),
+            'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['FaraData']

--- a/FaraData/migrations/0013_auto__add_historicaldoc__del_field_historical_document_type__del_field.py
+++ b/FaraData/migrations/0013_auto__add_historicaldoc__del_field_historical_document_type__del_field.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'HistoricalDoc'
+        db.create_table(u'FaraData_historicaldoc', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('historical_relationship', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['FaraData.Historical'])),
+            ('document_type', self.gf('django.db.models.fields.CharField')(max_length=255, null=True)),
+            ('document_link', self.gf('django.db.models.fields.CharField')(max_length=255, null=True)),
+            ('document_name', self.gf('django.db.models.fields.CharField')(max_length=255, null=True)),
+            ('document_date', self.gf('django.db.models.fields.DateField')(null=True, blank=True)),
+        ))
+        db.send_create_signal(u'FaraData', ['HistoricalDoc'])
+
+        # Deleting field 'Historical.document_type'
+        db.delete_column(u'FaraData_historical', 'document_type')
+
+        # Deleting field 'Historical.document_link'
+        db.delete_column(u'FaraData_historical', 'document_link')
+
+
+    def backwards(self, orm):
+        # Deleting model 'HistoricalDoc'
+        db.delete_table(u'FaraData_historicaldoc')
+
+        # Adding field 'Historical.document_type'
+        db.add_column(u'FaraData_historical', 'document_type',
+                      self.gf('django.db.models.fields.CharField')(max_length=255, null=True),
+                      keep_default=False)
+
+        # Adding field 'Historical.document_link'
+        db.add_column(u'FaraData_historical', 'document_link',
+                      self.gf('django.db.models.fields.CharField')(max_length=255, null=True),
+                      keep_default=False)
+
+
+    models = {
+        u'FaraData.client': {
+            'Meta': {'object_name': 'Client'},
+            'address1': ('django.db.models.fields.CharField', [], {'max_length': '300', 'null': 'True', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'client_name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'client_type': ('django.db.models.fields.CharField', [], {'max_length': '25', 'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Location']"}),
+            'meta_data': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['FaraData.MetaData']", 'null': 'True', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'})
+        },
+        u'FaraData.clientreg': {
+            'Meta': {'object_name': 'ClientReg'},
+            'client_id': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Client']"}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'link': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'meta_data': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['FaraData.MetaData']", 'null': 'True', 'blank': 'True'}),
+            'primary_contractor_id': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'primary_contractor'", 'null': 'True', 'symmetrical': 'False', 'to': u"orm['FaraData.Registrant']"}),
+            'reg_id': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Registrant']"})
+        },
+        u'FaraData.contact': {
+            'Meta': {'object_name': 'Contact'},
+            'client': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Client']", 'null': 'True'}),
+            'contact_type': ('django.db.models.fields.CharField', [], {'default': "'U'", 'max_length': '1'}),
+            'date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'link': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'lobbyist': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['FaraData.Lobbyist']", 'null': 'True', 'blank': 'True'}),
+            'meta_data': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.MetaData']", 'null': 'True', 'blank': 'True'}),
+            'recipient': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['FaraData.Recipient']", 'symmetrical': 'False'}),
+            'registrant': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Registrant']"})
+        },
+        u'FaraData.contribution': {
+            'Meta': {'object_name': 'Contribution'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'max_digits': '8', 'decimal_places': '2'}),
+            'date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'link': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'lobbyist': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Lobbyist']", 'null': 'True', 'blank': 'True'}),
+            'meta_data': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.MetaData']", 'null': 'True', 'blank': 'True'}),
+            'recipient': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Recipient']"}),
+            'registrant': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Registrant']"})
+        },
+        u'FaraData.disbursement': {
+            'Meta': {'object_name': 'Disbursement'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'max_digits': '12', 'decimal_places': '2'}),
+            'client': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Client']"}),
+            'date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'link': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'meta_data': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.MetaData']", 'null': 'True', 'blank': 'True'}),
+            'purpose': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'registrant': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Registrant']"}),
+            'subcontractor': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'subcontractor'", 'null': 'True', 'to': u"orm['FaraData.Registrant']"})
+        },
+        u'FaraData.gift': {
+            'Meta': {'object_name': 'Gift'},
+            'client': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['FaraData.Client']", 'null': 'True', 'blank': 'True'}),
+            'date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'link': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'meta_data': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.MetaData']", 'null': 'True', 'blank': 'True'}),
+            'purpose': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'recipient': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Recipient']", 'null': 'True', 'blank': 'True'}),
+            'registrant': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Registrant']"})
+        },
+        u'FaraData.historical': {
+            'Meta': {'object_name': 'Historical'},
+            'address': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location_represented': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'principal': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'principal_reg_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'principal_termination_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'registrant': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'registrant_no': ('django.db.models.fields.IntegerField', [], {}),
+            'registrant_reg_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'registrant_termination_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'})
+        },
+        u'FaraData.historicaldoc': {
+            'Meta': {'object_name': 'HistoricalDoc'},
+            'document_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'document_link': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'document_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'document_type': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'historical_relationship': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Historical']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'FaraData.lobbyist': {
+            'Meta': {'object_name': 'Lobbyist'},
+            'PAC_name': ('django.db.models.fields.CharField', [], {'max_length': '150', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'lobby_id': ('django.db.models.fields.CharField', [], {'max_length': '150', 'null': 'True', 'blank': 'True'}),
+            'lobbyist_name': ('django.db.models.fields.CharField', [], {'max_length': '150', 'null': 'True', 'blank': 'True'})
+        },
+        u'FaraData.location': {
+            'Meta': {'object_name': 'Location'},
+            'country_code': ('django.db.models.fields.CharField', [], {'max_length': '3', 'null': 'True', 'blank': 'True'}),
+            'country_grouping': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'location': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '200'}),
+            'region': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        u'FaraData.metadata': {
+            'Meta': {'object_name': 'MetaData'},
+            'end_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'form': ('django.db.models.fields.CharField', [], {'max_length': '300'}),
+            'is_amendment': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'link': ('django.db.models.fields.CharField', [], {'max_length': '255', 'primary_key': 'True', 'db_index': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'processed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'reviewed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'upload_date': ('django.db.models.fields.DateField', [], {'null': 'True'})
+        },
+        u'FaraData.payment': {
+            'Meta': {'object_name': 'Payment'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'max_digits': '12', 'decimal_places': '2'}),
+            'client': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Client']"}),
+            'date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'fee': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'link': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'meta_data': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.MetaData']", 'null': 'True', 'blank': 'True'}),
+            'purpose': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'registrant': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['FaraData.Registrant']"}),
+            'sort_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'subcontractor': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'payment_subcontractor'", 'null': 'True', 'to': u"orm['FaraData.Registrant']"})
+        },
+        u'FaraData.recipient': {
+            'Meta': {'object_name': 'Recipient'},
+            'agency': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'bioguide_id': ('django.db.models.fields.CharField', [], {'max_length': '7', 'null': 'True', 'blank': 'True'}),
+            'crp_id': ('django.db.models.fields.CharField', [], {'max_length': '9', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '150', 'null': 'True'}),
+            'office_detail': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'state_local': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '300', 'null': 'True', 'blank': 'True'})
+        },
+        u'FaraData.registrant': {
+            'Meta': {'object_name': 'Registrant'},
+            'address': ('django.db.models.fields.CharField', [], {'max_length': '300', 'null': 'True', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'clients': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['FaraData.Client']", 'null': 'True', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'lobbyists': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['FaraData.Lobbyist']", 'null': 'True', 'blank': 'True'}),
+            'meta_data': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['FaraData.MetaData']", 'null': 'True', 'blank': 'True'}),
+            'reg_id': ('django.db.models.fields.IntegerField', [], {'primary_key': 'True'}),
+            'reg_name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '2', 'null': 'True', 'blank': 'True'}),
+            'terminated_clients': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'terminated_clients'", 'null': 'True', 'symmetrical': 'False', 'to': u"orm['FaraData.Client']"}),
+            'zip_code': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['FaraData']

--- a/FaraData/models.py
+++ b/FaraData/models.py
@@ -218,4 +218,31 @@ class ClientReg(models.Model):
         return "%s - %s" % (self.client_id, self.reg_id)
 
 
-    
+#a historical data source was found later that lists
+#principals in a machine-readable format
+#we're scraping it into a separate table so we can make
+#appropriate decisions about what to integrate where
+#so we don't clobber existing, good, human-entered data
+class Historical(models.Model):
+    principal = models.CharField(max_length=255, null=True)
+    principal_reg_date = models.DateField(null=True, blank=True)
+    principal_termination_date = models.DateField(null=True, blank=True)
+    address = models.CharField(max_length=255, null=True)
+    state = models.CharField(max_length=255, null=True)
+    location_represented = models.CharField(max_length=255, null=True)
+    registrant = models.CharField(max_length=255, null=True)
+    registrant_no = models.IntegerField()
+    registrant_reg_date = models.DateField(null=True, blank=True)
+    registrant_termination_date = models.DateField(null=True, blank=True)
+
+    def __unicode__(self):
+        return "%s - %s" % (self.principal, self.registrant)
+
+class HistoricalDoc(models.Model):
+    historical_relationship = models.ForeignKey(Historical)
+    document_type = models.CharField(max_length=255, null=True)
+    document_link = models.CharField(max_length=255, null=True)
+    document_name = models.CharField(max_length=255, null=True)
+    document_date = models.DateField(null=True, blank=True)
+    def __unicode__(self):
+        return self.document_name

--- a/FaraData/tests.py
+++ b/FaraData/tests.py
@@ -1,3 +1,129 @@
-from django.test import TestCase
 
-# Create your tests here.
+from django.test import SimpleTestCase
+from django.core import management
+from FaraData.models import Client, Registrant, ClientReg, Historical, HistoricalDoc, MetaData, Location
+
+
+class PlainDataMergeTestCase(SimpleTestCase):
+    def setUp(self):
+        Historical.objects.create(principal="Rachel",
+            location_represented="Sunlight",
+            registrant="Bob",
+            registrant_no="123")
+        hist = Historical.objects.all()[0]
+        HistoricalDoc.objects.create(historical_relationship=hist,
+            document_link="www.example.com")
+        MetaData.objects.create(link="www.example.com")
+        Location.objects.create(location="Sunlight")
+
+    def test_data_merge_with_no_dupes(self):
+        """merge_feeds is successful when no duplicates are present"""
+        management.call_command('merge_feeds')
+        self.assertEqual(Client.objects.count(),1)
+        self.assertEqual(Registrant.objects.count(),1)
+        self.assertEqual(ClientReg.objects.count(),1)
+
+    def tearDown(self):
+        Historical.objects.all().delete()
+        HistoricalDoc.objects.all().delete()
+        MetaData.objects.all().delete()
+        Location.objects.all().delete()
+        Client.objects.all().delete()
+        Registrant.objects.all().delete()
+        ClientReg.objects.all().delete()
+
+class KnownRegMergeTestCase(SimpleTestCase):
+    def setUp(self):
+        Historical.objects.create(principal="Rachel",
+            location_represented="Sunlight",
+            registrant="Bob",
+            registrant_no="123")
+        hist = Historical.objects.all()[0]
+        HistoricalDoc.objects.create(historical_relationship=hist,
+            document_link="www.example.com")
+        Registrant.objects.create(reg_id=123,
+            reg_name="Bob")
+        MetaData.objects.create(link="www.example.com")
+        Location.objects.create(location="Sunlight")
+
+    def test_data_merge_with_known_reg(self):
+        """merge_feeds is successful when registrant already known"""
+        management.call_command('merge_feeds')
+        self.assertEqual(Client.objects.count(),1)
+        self.assertEqual(Registrant.objects.count(),1)
+        self.assertEqual(ClientReg.objects.count(),1)
+
+    def tearDown(self):
+        Historical.objects.all().delete()
+        HistoricalDoc.objects.all().delete()
+        MetaData.objects.all().delete()
+        Location.objects.all().delete()
+        Client.objects.all().delete()
+        Registrant.objects.all().delete()
+        ClientReg.objects.all().delete()
+
+class KnownClientMergeTestCase(SimpleTestCase):
+    def setUp(self):
+        Historical.objects.create(principal="Rachel",
+            location_represented="Sunlight",
+            registrant="Bob",
+            registrant_no="123")
+        hist = Historical.objects.all()[0]
+        HistoricalDoc.objects.create(historical_relationship=hist,
+            document_link="www.example.com")
+        sunlight = Location.objects.create(location="Sunlight")
+        Client.objects.create(client_name="Rachel",
+            location=sunlight)
+        MetaData.objects.create(link="www.example.com")
+        
+
+    def test_data_merge_with_known_reg(self):
+        """merge_feeds is successful when registrant already known"""
+        management.call_command('merge_feeds')
+        self.assertEqual(Client.objects.count(),1)
+        self.assertEqual(Registrant.objects.count(),1)
+        self.assertEqual(ClientReg.objects.count(),1)
+
+    def tearDown(self):
+        Historical.objects.all().delete()
+        HistoricalDoc.objects.all().delete()
+        MetaData.objects.all().delete()
+        Location.objects.all().delete()
+        Client.objects.all().delete()
+        Registrant.objects.all().delete()
+        ClientReg.objects.all().delete()
+
+
+class UnrelatedClientMergeTestCase(SimpleTestCase):
+    def setUp(self):
+        Historical.objects.create(principal="Rachel",
+            location_represented="Sunlight",
+            registrant="Bob",
+            registrant_no="123")
+        hist = Historical.objects.all()[0]
+        HistoricalDoc.objects.create(historical_relationship=hist,
+            document_link="www.example.com")
+        md = MetaData.objects.create(link="www.example.com")
+        sunlight = Location.objects.create(location="Sunlight")
+        client = Client.objects.create(client_name="Miles",
+            location=sunlight)
+        client.meta_data.add(md)
+        client.save()
+        
+        
+
+    def test_data_merge_with_known_reg(self):
+        """merge_feeds does not add clients if any clients are found for metadata"""
+        management.call_command('merge_feeds')
+        self.assertEqual(Client.objects.count(),1)
+        self.assertEqual(Registrant.objects.count(),1)
+        self.assertEqual(ClientReg.objects.count(),1)
+
+    def tearDown(self):
+        Historical.objects.all().delete()
+        HistoricalDoc.objects.all().delete()
+        MetaData.objects.all().delete()
+        Location.objects.all().delete()
+        Client.objects.all().delete()
+        Registrant.objects.all().delete()
+        ClientReg.objects.all().delete()

--- a/FaraData/tests.py
+++ b/FaraData/tests.py
@@ -112,8 +112,41 @@ class UnrelatedClientMergeTestCase(SimpleTestCase):
         
         
 
-    def test_data_merge_with_known_reg(self):
+    def test_data_merge_unrelated_client(self):
         """merge_feeds does not add clients if any clients are found for metadata"""
+        management.call_command('merge_feeds')
+        self.assertEqual(Client.objects.count(),1)
+        self.assertEqual(Registrant.objects.count(),1)
+        self.assertEqual(ClientReg.objects.count(),1)
+
+    def tearDown(self):
+        Historical.objects.all().delete()
+        HistoricalDoc.objects.all().delete()
+        MetaData.objects.all().delete()
+        Location.objects.all().delete()
+        Client.objects.all().delete()
+        Registrant.objects.all().delete()
+        ClientReg.objects.all().delete()
+
+class KnownClientMergeTestCase(SimpleTestCase):
+    def setUp(self):
+        Historical.objects.create(principal="Rachel",
+            location_represented="Sunlight",
+            registrant="Bob",
+            registrant_no="123")
+        hist = Historical.objects.all()[0]
+        HistoricalDoc.objects.create(historical_relationship=hist,
+            document_link="www.example.com")
+        md = MetaData.objects.create(link="www.example.com")
+        sunlight = Location.objects.create(location="Sunlight")
+        client = Client.objects.create(client_name="Rachel",
+            location=sunlight)
+        client.save()
+        
+        
+
+    def test_data_merge_unrelated_client(self):
+        """merge_feeds does not add new clients if name matches existing client"""
         management.call_command('merge_feeds')
         self.assertEqual(Client.objects.count(),1)
         self.assertEqual(Registrant.objects.count(),1)

--- a/fara_feed/management/commands/historical_feed.py
+++ b/fara_feed/management/commands/historical_feed.py
@@ -27,6 +27,11 @@ documents = []
 #changing pgR_min_row modifies the starting point
 
 
+#building the historical scraper completely separately
+#from the regular fara feed scraper, and then a 
+#task to combine them so that we always have the raw
+#historical data and can combine when needed.
+
 class Command(BaseCommand):
     help = "Crawls the DOJ's FARA site looking for new documents."
     can_import_settings = True

--- a/fara_feed/management/commands/historical_feed.py
+++ b/fara_feed/management/commands/historical_feed.py
@@ -1,0 +1,180 @@
+import scrapelib
+import datetime
+
+from bs4 import BeautifulSoup
+
+from django.core.management.base import BaseCommand, CommandError
+from django.core.files.storage import default_storage
+from django.conf import settings 
+
+from FaraData.models import Historical, HistoricalDoc
+
+head = ({'User-Agent': 'Mozilla/5.0'})
+
+
+documents = []
+
+
+###Historical URLs look like this:
+#https://efile.fara.gov/pls/apex/f?p=<p_flow_id>:<p_flow_step_id>:<p_instance>:<p_widget_action_mod>:<?>:<?>:<other parameter assignments?>
+#where the params are separated by : and not named
+#the only param we want to manipulate is <p_widget_action_mod>
+#which needs to be in this format:
+#pgR_min_row=1max_rows=15rows_fetched=15
+#and max_rows and rows_fetched should say at 15
+#because it always returns 15 anyway unless some other paramater
+#I haven't yet figured out is changed.
+#changing pgR_min_row modifies the starting point
+
+
+class Command(BaseCommand):
+    help = "Crawls the DOJ's FARA site looking for new documents."
+    can_import_settings = True
+
+    def handle(self, *args, **options):
+        self.scraper = scrapelib.Scraper()
+        self.base_url = "https://efile.fara.gov/pls/apex/"
+        self.per_page = 15 #right now we have no way of displaying
+                            #anything but 15 at a time, this shouldn't
+                            #be changed without a much better understanding
+                            #of how they're passing parameters
+        start_record = 0
+        end_record = 0
+        total_records = 1
+        while end_record < total_records:
+            page_param = "pgR_min_row={}max_rows={}rows_fetched={}"
+            page_param = page_param.format(end_record+1, self.per_page, self.per_page)
+            next_page = self.get_page(page_param)
+            data_table = next_page.find('div', {'id' : 'apexir_DATA_PANEL'})
+            self.process_records(data_table.findAll("tr"))
+            page_info = next_page.find("td", { "class" : "pagination" }).text
+            page_info = page_info.replace('of', '-')
+            record_info = page_info.split('-')
+            start_record, end_record, total_records = [int(r.strip()) for r in record_info]
+            num_records_on_page = end_record-start_record+1
+
+    def get_page(self, next_page_param):
+        base_url = "https://efile.fara.gov/pls/apex/f?p=171:136:6066396580856:{}:NO::P136_CNTRY:ALL"
+        page_url = base_url.format(next_page_param)
+        page = self.scraper.get(page_url).text
+        return BeautifulSoup(page)
+
+    def get_docs(self, link, relationship_record):
+        page = self.scraper.get(self.base_url+link).text
+        soup = BeautifulSoup(page)
+        try:
+            soup.findAll('td', { "headers" : "DATE_STAMPED"})[0]
+        except IndexError:
+            #there are no records on this page, skip documents for this reln
+            print "no records on %s" % self.base_url+link
+            return []
+
+        trs = soup.findAll('tr')
+        for row in trs:
+            date_stamped = row.find('td', {"headers":"DATE_STAMPED"})
+            if date_stamped is None:
+                #this was not a relevant TR
+                continue
+
+            date_stamped = clean_date_field(date_stamped)
+            doc_link = row.find('td', {"headers":"DOCLINK"})
+            doc_type = clean_field(row.find('td', {"headers":"DOCUMENT_TYPE"}))
+            doc_name = clean_field(doc_link)
+            doc_link = doc_link.a['href']
+
+            if not doc_name:
+                #there is no document pdf
+                continue
+            if doc_name.lower() != relationship_record.principal.lower():
+                continue
+
+            existing_docs = HistoricalDoc.objects.filter(document_link=doc_link,
+                historical_relationship=relationship_record)
+            
+            if len(existing_docs) == 0:
+                print "%s saved" % doc_link
+                doc = HistoricalDoc(historical_relationship=relationship_record,
+                                    document_type=doc_type,
+                                    document_link=doc_link,
+                                    document_name=doc_name,
+                                    document_date=date_stamped)
+                doc.save()
+
+
+
+
+
+    def process_records(self, records):
+        #find document's info
+        country = None
+        for record in records:
+            if record.th:
+                country_span = record.th.find('span', { "class" : "apex_break_headers" })
+                if country_span:
+                    country = country_span.text.strip()
+            
+            principal = record.find('td',{"headers": "FP_NAME BREAK_COUNTRY_NAME_1"})
+            if principal:
+                principal = principal.text.strip()
+            if not principal:
+                continue
+            if not country:
+                print "don't know which country, skipping"
+                continue
+            fp_reg_date = clean_date_field(record.find('td',{"headers": "FP_REG_DATE BREAK_COUNTRY_NAME_1"}))
+            fp_term_date = clean_date_field(record.find('td',{"headers": "TERMINATION_DATE BREAK_COUNTRY_NAME_1"}))
+            address = clean_field(record.find('td',{"headers": "ADDRESS_1 BREAK_COUNTRY_NAME_1"}))
+            state = clean_field(record.find('td',{"headers": "STATE BREAK_COUNTRY_NAME_1"}))
+            reg_name = clean_field(record.find('td',{"headers": "REGISTRANT_NAME BREAK_COUNTRY_NAME_1"}))
+            reg_num = clean_field(record.find('td',{"headers": "REG_NUMBER BREAK_COUNTRY_NAME_1"}))
+            reg_reg_date = clean_date_field(record.find('td',{"headers": "REG_DATE BREAK_COUNTRY_NAME_1"}))
+            reg_term_date = clean_date_field(record.find('td',{"headers": "REG_TERM_DATE BREAK_COUNTRY_NAME_1"}))
+
+            doc_page_link = record.find('td',{"headers": "LINK BREAK_COUNTRY_NAME_1"}).a["href"]
+
+            #same principal and registrant with same reg dates for both
+            #should be enough to determine uniqueness (I hope)
+            obj_count = Historical.objects.filter(principal=principal,
+                                        registrant=reg_name,
+                                        principal_reg_date=fp_reg_date,
+                                        registrant_reg_date=reg_reg_date).all()
+
+            if len(obj_count) > 0:
+                hist = obj_count[0]
+
+            else:
+                hist = Historical(principal=principal,
+                    principal_reg_date = fp_reg_date,
+                    principal_termination_date = fp_term_date,
+                    address = address,
+                    state = state,
+                    location_represented = country,
+                    registrant = reg_name,
+                    registrant_no = reg_num,
+                    registrant_reg_date = reg_reg_date,
+                    registrant_termination_date = reg_term_date)
+
+                
+
+                hist.save()
+
+
+            self.get_docs(doc_page_link, hist)
+
+
+def clean_field(field):
+    if field:
+        field = field.text.strip()
+    if field:
+        return field
+    return None
+
+def clean_date_field(date):
+    date = clean_field(date)
+    if date:
+        return datetime.datetime.strptime(date, '%m/%d/%Y')
+    return None
+
+      
+
+

--- a/fara_feed/management/commands/merge_feeds.py
+++ b/fara_feed/management/commands/merge_feeds.py
@@ -1,0 +1,124 @@
+import scrapelib
+import datetime
+
+from bs4 import BeautifulSoup
+
+from django.core.management.base import BaseCommand, CommandError
+from django.core.files.storage import default_storage
+from django.conf import settings 
+
+from FaraData.models import Historical, HistoricalDoc, MetaData, Registrant, Client, Location, ClientReg
+
+head = ({'User-Agent': 'Mozilla/5.0'})
+
+
+documents = []
+
+
+class Command(BaseCommand):
+    help = "Merges data from fara_feed and historical_feed."
+    can_import_settings = True
+
+    def handle(self, *args, **options):
+        for doc in HistoricalDoc.objects.all():
+            link = doc.document_link
+            related_fara_metadata = MetaData.objects.filter(link=link)
+            if len(related_fara_metadata) == 0:
+                #skip for now
+                #we may want to add the metadata
+                continue
+
+
+            #look for the registrant
+            hist_reln = doc.historical_relationship
+            registrant_no = hist_reln.registrant_no
+            registrant = Registrant.objects.filter(reg_id=registrant_no)
+            if len(registrant) == 1:
+                registrant = registrant[0]
+            elif len(registrant) == 0:
+                registrant = Registrant(reg_id=registrant_no,
+                                        reg_name=hist_reln.registrant,
+                                        metadata=related_fara_metadata[0])
+                registrant.save()
+            else:
+                #there's more tha one registrant with the same ID
+                #what should we do?
+                print("Multiple registrants with that ID, moving on!")
+                continue
+
+
+            #look for the client
+            names = create_search_names(hist_reln.principal)
+            for name in names:
+                clients = Client.objects.filter(client_name__iexact=name)
+                if len(clients) > 0:
+                    break
+
+            if len(clients) == 1:
+                client = clients[0]
+            elif len(clients) > 1:
+                #multiple matching clients, help! skipping for now
+                print("Multiple clients with that name, moving on")
+            else:
+                #create the client
+                #but first we have to match the location.
+                location = Location.objects.filter(location__iexact=hist_reln.location_represented)
+                if len(location) == 1:
+                    location = location[0]
+                else:
+                    print "Unknown location {}".format(hist_reln.location_represented)
+                    continue
+
+                client = Client(location=location,
+                                client_name=name.strip(),
+                                address1=hist_reln.address,
+                                state=hist_reln.state)
+                client.save()
+
+
+            for md in related_fara_metadata:
+                print "match"
+
+                new_registrant = False
+
+                #with registrants we can use their id system to dedup
+                #so we'll just add them if they aren't in there
+                if not registrant in md.registrant_set.all():
+                    md.registrant_set.add(registrant)
+                    md.save()
+                    new_registrant = True
+
+                #for clients we have to be more careful since there's no id
+                #so we'll only add clients if the client_set is empty
+                #otherwise we may add duplicates
+                #and presumably only human-entered data is in the db and it's good?
+                #we also have to try to match clients by name. ick.
+                if len(md.client_set.all()) == 0:
+                    md.client_set.add(client)
+                    md.save()
+                    for r in md.registrant_set.all():
+                        print "add clientregs"
+                        ClientReg(client_id=client,
+                                reg_id=r).save()
+
+                elif new_registrant:
+                    for c in md.client_set.all():
+                        print "add clientregs 2"
+                        ClientReg(client_id=c,
+                                reg_id=registrant).save()
+
+
+
+
+
+
+def create_search_names(name):
+    name = name.strip()
+    names = [name]
+    #do any other name-related replacements here
+    #eg:
+    if "Saint" in name:
+        names.append(name.replace("Saint","St"))
+        names.append(name.replace("Saint","St."))
+
+    return names

--- a/fara_feed/management/commands/merge_feeds.py
+++ b/fara_feed/management/commands/merge_feeds.py
@@ -60,15 +60,25 @@ class Command(BaseCommand):
                 #multiple matching clients, help! skipping for now
                 print("Multiple clients with that name, moving on")
             else:
+                location_text = hist_reln.location_represented
+
                 #create the client
                 #but first we have to match the location.
-                location = Location.objects.filter(location__iexact=hist_reln.location_represented)
+
+                #clean up known location mismatches
+                location_dict = {'SOMALI DEMOCRATIC REPUBLIC' : 'SOMALIA',
+                                'KOREA REPUBLIC OF' : 'SOUTH KOREA',
+                                'BOSNIA-HERZEGOVINA' : 'BOSNIA AND HERZEGOVINA'}
+                if location_text in location_dict:
+                    location_text = location_dict[location_text]
+
+                location = Location.objects.filter(location__iexact=location_text)
                 if len(location) == 1:
                     location = location[0]
                 else:
-                    print "Unknown location {}".format(hist_reln.location_represented)
+                    print "Unknown location {}".format(location_text)
                     continue
-
+                print name
                 client = Client(location=location,
                                 client_name=name.strip(),
                                 address1=hist_reln.address,
@@ -77,7 +87,6 @@ class Command(BaseCommand):
 
 
             for md in related_fara_metadata:
-                print "match"
 
                 new_registrant = False
 
@@ -97,13 +106,11 @@ class Command(BaseCommand):
                     md.client_set.add(client)
                     md.save()
                     for r in md.registrant_set.all():
-                        print "add clientregs"
                         ClientReg(client_id=client,
                                 reg_id=r).save()
 
                 elif new_registrant:
                     for c in md.client_set.all():
-                        print "add clientregs 2"
                         ClientReg(client_id=c,
                                 reg_id=registrant).save()
 


### PR DESCRIPTION
This PR adds the historical data source which has additional machine-readable information about clients.

It gets this data using the management command historical_feed. That command gets data but DOES NOT merge it into the existing DB. I chose to do this in 2 steps because the 2nd step could be destructive and I wanted to make it as easy as possible to decouple the scraping and acquisition parts.

Data is merged with existing scraped data via the merge_feeds management command. If data exists, I defer to existing data since that was generally hand-entered.

I have not integrated any of these changes into the front-end or given any thought to how often these commands ought to be run.

Finally, I wrote tests for the merge_feeds command because that could be destructive of existing data. The tests can be run using ./manage.py test FaraData.
